### PR TITLE
Reference bm-core-ui from npm rather than locally

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "BMPresentationController",
-  "version": "2.6.1",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1757,6 +1757,16 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
+    },
+    "bm-core-ui": {
+      "version": "2.6.0-beta.2",
+      "resolved": "https://registry.npmjs.org/bm-core-ui/-/bm-core-ui-2.6.0-beta.2.tgz",
+      "integrity": "sha512-JlkeGDCJBw0kOdp3ZNE4LO6yCSQunXDoq8xj4ECwkxptxlFihMq/kJTXbSJ0fOY24eW/4PZA26NAhJtaW9rZvA==",
+      "dev": true,
+      "requires": {
+        "kiwi.js": "^1.1.2",
+        "velocity-animate": "^1.5.2"
+      }
     },
     "bn.js": {
       "version": "4.11.8",
@@ -5320,6 +5330,12 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "kiwi.js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/kiwi.js/-/kiwi.js-1.1.2.tgz",
+      "integrity": "sha512-O/6vug4T5j7eEBYdtxdI4BrPcJyp0qC0ai0oka2tGwJfbUXYSgCQil+dzzPmDCZxSkGcIvkaoQGy05tmCCfa5g==",
+      "dev": true
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -8347,6 +8363,12 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
+    },
+    "velocity-animate": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/velocity-animate/-/velocity-animate-1.5.2.tgz",
+      "integrity": "sha512-m6EXlCAMetKztO1ppBhGU1/1MR3IiEevO6ESq6rcrSQ3Q77xYSW13jkfXW88o4xMrkXJhy/U7j4wFR/twMB0Eg==",
       "dev": true
     },
     "verror": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
         "@types/node": "^12.12.14",
         "@types/webpack-env": "^1.14.1",
         "babel-loader": "^8.0.6",
+        "bm-core-ui": "2.6.0-beta.2",
         "clean-webpack-plugin": "^3.0.0",
         "copy-webpack-plugin": "^5.0.5",
         "css-loader": "^3.2.1",

--- a/src/BMPresentationController.ide.ts
+++ b/src/BMPresentationController.ide.ts
@@ -1,7 +1,6 @@
-///<reference path="../../BMCoreUI/build/ui/BMCoreUI/BMCoreUI.d.ts"/>
-
 import { TWWidgetDefinition, autoResizable, description, property, defaultValue, bindingTarget, service, event, bindingSource, nonEditable, willSet, didSet, TWPropertySelectOptions, selectOptions, hidden } from 'typescriptwebpacksupport/widgetidesupport';
 import {BMPresentationControllerAnchorKind} from './shared/constants'
+import { NO, YES } from 'bm-core-ui';
 
 const anchorOptions: TWPropertySelectOptions[] = [
     {text: 'Event Origin', value: BMPresentationControllerAnchorKind.EventOrigin},

--- a/src/BMPresentationController.runtime.ts
+++ b/src/BMPresentationController.runtime.ts
@@ -1,6 +1,7 @@
 
 import { TWWidgetDefinition, property, canBind, didBind, TWEvent, event, service } from 'typescriptwebpacksupport/widgetruntimesupport';
 import { BMPresentationControllerAnchorKind } from './shared/constants';
+import { BMWindow, BMView, DOMNode, NO, BMWindowDelegate, BMPoint, BMRect, BMFunctionCollectionMake, YES, BMLayoutConstraint, BMLayoutAttribute, BMLayoutConstraintRelation, BMRectMake, BMPopover, BMSizeMake, BMPointMake, BMRectMakeWithOrigin, BMWindowMakeWithFrame, BMSize } from 'bm-core-ui';
 
 
 declare global {
@@ -317,7 +318,7 @@ let BMControllerSerialVersion = 0;
 		var containerNode: HTMLDivElement = document.createElement('div');
 		containerNode.classList.add('BMControllerMashup');
 		args.intoController.contentView.node.appendChild(containerNode);
-		var container: $ = $(containerNode);
+		var container: JQuery = $(containerNode);
 
 		// If there was a previous mashup that should be destroyed,
 		// the new mashup starts out transparent

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,11 +43,14 @@ module.exports = function (env, argv) {
             // this is the path when viewing the widget in thingworx
             publicPath: `../Common/extensions/${packageName}/ui/${packageJson.name}/`
         },
+        externals: {
+            'bm-core-ui': 'window'
+        },
         plugins: [
             // delete build and zip folders
             new CleanWebpackPlugin({
                 cleanOnceBeforeBuildPatterns: [path.resolve('build/**'), path.resolve('zip/**')]
-            }),        
+            }),
             // in case we just want to copy some resources directly to the widget package, then do it here
             new CopyWebpackPlugin([{ from: 'src/static', to: 'static' }]),
             // in case the extension contains entities, copy them as well


### PR DESCRIPTION
This change imports bm-core-ui from npm rather than locally.
This makes it easier to develop on top of it, without needing to care about other references.

The change in `webpack.config.js` makes it so the `bm-core-ui` module is not included, and still referenced from the global `window`